### PR TITLE
What happens with caret ranges on a merge conflict in lockfiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "react": "^19.0.0-rc-cc1ec60d0d-20240607"
+    "react": "^19.0.0-rc-a532d91d01-20240610"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-react@^19.0.0-rc-cc1ec60d0d-20240607:
-  version "19.0.0-rc-cc1ec60d0d-20240607"
-  resolved "https://registry.yarnpkg.com/react/-/react-19.0.0-rc-cc1ec60d0d-20240607.tgz#887ef55baa5de87d62a1743b1a4ec2ba447bd3c1"
-  integrity sha512-q8A0/IdJ2wdHsjDNO1igFcSSFIMqSKmO7oJZtAjxIA9g0klK45Lxt15NQJ7z7cBvgD1r3xRTtQ/MAqnmwYHs1Q==
+react@^19.0.0-rc-a532d91d01-20240610:
+  version "19.0.0-rc-a532d91d01-20240610"
+  resolved "https://registry.yarnpkg.com/react/-/react-19.0.0-rc-a532d91d01-20240610.tgz#6216ca88ae5fde1ae98f71655265a163aab9d8bc"
+  integrity sha512-lb6bDjzM3jLdDXKESjxETLLycWbA8HVxXtUa9Hg0iH+/Z7xRi1A51OpZc6YCLNoRI3AnA6fMNIpiLxQBwSh0Bg==


### PR DESCRIPTION
1. checkout this branch
2. rebase on master
3. Accept incoming change (i.e. `"react": "^19.0.0-rc-a532d91d01-20240610"`)

Hypothesis: Lockfile will no longer use `19.0.0-rc-a532d91d01-20240610` but the highest matching `^19.0.0-rc-a532d91d01-20240610` because we used a caret range
Actual: yarn will respect the incoming. The hypothesis is based on observed behavior of PNPM